### PR TITLE
CMakeLists: allow custom libraries directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(libpillowfight)
 set(CMAKE_BUILD_TYPE Release)
+set(LIBDIR lib CACHE STRING "object code libraries directory")
 
 add_definitions(-DNO_PYTHON)
 include_directories(include)
@@ -21,7 +22,7 @@ add_library(pillowfight SHARED
 	src/pillowfight/util.c
 )
 
-install (TARGETS pillowfight DESTINATION lib)
+install (TARGETS pillowfight DESTINATION ${LIBDIR})
 install (FILES
 	include/pillowfight/pillowfight.h
 	include/pillowfight/util.h


### PR DESCRIPTION
allows to install libpillowfight.so under /usr/lib64 (e.g. on fedora)
with `cmake -DLIBDIR=lib64 .`